### PR TITLE
ci: :construction_worker: add running some static analysis tools on each push

### DIFF
--- a/.github/workflows/run-static-analysis.yml
+++ b/.github/workflows/run-static-analysis.yml
@@ -1,0 +1,38 @@
+name: Run Static Analysis
+
+on: push
+
+jobs:
+  static-analysis:
+    runs-on: ${{ matrix.os }}
+    name: Static Analysis - OTP ${{ matrix.otp }} | Elixir ${{ matrix.elixir }} | OS ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+        otp: [24]
+        elixir: [1.14.4]
+    services:
+      db:
+        image: postgres:latest
+        ports: ['5432:5432']
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp }}
+          elixir-version: ${{ matrix.elixir }}
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Check for compile warnings
+        run: mix compile --warnings-as-errors
+
+      - name: Check formatting
+        run: mix format --check-formatted 
+
+      - name: Run unit tests
+        run: mix test


### PR DESCRIPTION
For this commit, we are just running the following:

- mix compile --warnings-as-errors
- mix format --check-formatted
- mix test